### PR TITLE
Parser: assert zero-based index is non-negative

### DIFF
--- a/src/main/java/capybara/Parser.java
+++ b/src/main/java/capybara/Parser.java
@@ -162,7 +162,10 @@ public class Parser {
             if (n <= 0) {
                 throw new NumberFormatException();
             }
-            return n - 1;
+            int idx0 = n - 1;
+            // ASSERT: caller relies on a zero-based, non-negative index
+            assert idx0 >= 0 : "Zero-based index must be non-negative";
+            return idx0;
         } catch (NumberFormatException e) {
             throw new CapyException("Capybara tilts head… '" + raw + "' is not a valid task number.");
         }


### PR DESCRIPTION
The parseOneBasedIndex() method converts a user-supplied task number into a zero-based index. The code implicitly assumes the resulting index is always non-negative after validation.

This assumption is not documented, and if it were ever violated due to future changes, the error would surface only later when accessing the task list.

Let's add an assertion to check that the computed zero-based index is non-negative before returning it. This documents the invariant and ensures such violations are caught early during development.